### PR TITLE
Remove setting j.core.db because it is set at start4core now

### DIFF
--- a/apps/portalbase/portal_start.py
+++ b/apps/portalbase/portal_start.py
@@ -25,7 +25,6 @@ def cli(ctx, instance):
 def start(ctx, instance):
     if not j.core.db:
         j.clients.redis.start4core()
-        j.core.db = j.clients.redis.get4core()
     instance = instance or ctx.obj.get('INSTANCE')
     cfg = j.data.serializer.yaml.load('%s/portals/%s/config.yaml' % (j.dirs.CFGDIR, instance))
     j.application.instanceconfig = cfg


### PR DESCRIPTION
#### What this PR resolves:
Remove setting j.core.db

#### Changes proposed in this PR:

-
-


**Version**: 

**Fixes**: #
