### PR TITLE
remove redundant h2 test line in services.wiki

### DIFF
--- a/apps/portalbase/AYS/Details/Services.wiki
+++ b/apps/portalbase/AYS/Details/Services.wiki
@@ -1,6 +1,5 @@
 @usedefaults
 h3. Services
-h2. test
 
 {{datatables_use}}
 {{aysservices reponame:$$reponame}}


### PR DESCRIPTION
#### What this PR resolves:
Meaningless ".h2 test" line in services.wiki

#### Changes proposed in this PR:

-
-


**Version**: 

**Fixes**: #
