### PR TITLE
skip adding the host header when forwarding to proxy

### DIFF
--- a/JumpScale9Portal/portal/PageProcessor.py
+++ b/JumpScale9Portal/portal/PageProcessor.py
@@ -299,7 +299,7 @@ class PageProcessor():
         for name, value in ctx.env.items():
             if name.startswith('HTTP_'):
                 if name == 'HTTP_HOST':
-                    headers['Host'] = value
+                    continue
                 else:
                     headers[name[5:].replace('_', '-')] = value
         desturl = proxy['dest'] + path[len(proxy['path']):]


### PR DESCRIPTION
#### What this PR resolves:
https://github.com/Jumpscale/portal9/issues/43

#### Changes proposed in this PR:

-
-


**Version**: 

**Fixes**: #
