### PR TITLE
move pip installation to prefab portal

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,2 @@
-#for development mode
-apt-get install -y  libsnappy-dev
-pip3 install -e .
-
 # install portal
 js9 'j.tools.prefab.get().apps.portal.install()'


### PR DESCRIPTION
#### What this PR resolves:
Changes pip install from `install.sh` to portal prefab, since prefab portal is already used in the script.


**Version**: 9.1.1

Related to https://github.com/Jumpscale/prefab9/issues/24
