### PR TITLE
correct login in production mode

### DIFF
--- a/apps/portalbase/macros/page/login/1_main.py
+++ b/apps/portalbase/macros/page/login/1_main.py
@@ -47,24 +47,29 @@ def main(j, args, params, tags, tasklet):
     head = """
 <title>Login</title>
     """
+    title = ''
+    if not j.portal.tools.server.active.cfg.get('force_oauth_instance'):
+        title = '<h4>Access Denied Please Login</h4>'
     body = """
     <form id="loginform" class="form-signin container" method="post" action="/$$path$$querystr">
-       <h4>Access Denied Please Login</h4>
+       {}
        <div class="col-sm-offset-3 col-md-6 login-screen">
-        <div class="login-form">
-          <div class="form-group">
-            <input type="text" class="form-control login-field" value="" name="user_login_" placeholder="Enter your username" id="login-name">
-            <label class="login-field-icon fui-user" for="login-name"></label>
-          </div>
+        <div class="login-form">""".format(title)
+    if not j.portal.tools.server.active.cfg.get('production'):
+        body += """
+        <div class="form-group">
+          <input type="text" class="form-control login-field" value="" name="user_login_" placeholder="Enter your username" id="login-name">
+          <label class="login-field-icon fui-user" for="login-name"></label>
+        </div>
 
-          <div class="form-group">
-            <input type="password" class="form-control login-field" value="" name="passwd" placeholder="Password" id="login-pass">
-            <label class="login-field-icon fui-lock" for="login-pass"></label>
-          </div>
+        <div class="form-group">
+          <input type="password" class="form-control login-field" value="" name="passwd" placeholder="Password" id="login-pass">
+          <label class="login-field-icon fui-lock" for="login-pass"></label>
+        </div>
 
-          <button class="btn btn-primary btn-lg btn-block mbm" type="submit">Sign in</button>"""
+        <button class="btn btn-primary btn-lg btn-block mbm" type="submit">Sign in</button>"""
     name = j.portal.tools.server.active.cfg.get('force_oauth_instance')
-    if name:
+    if name and j.portal.tools.server.active.cfg.get('production'):
         body += '''
         <a class="btn btn-block btn-social btn-%s" href=/restmachine/system/oauth/authenticate?type=%s>
           <i class="fa fa-%s"></i> <span>Login with %s</span>

--- a/apps/portalbase/wiki/System/AccessDenied/AccessDenied.wiki
+++ b/apps/portalbase/wiki/System/AccessDenied/AccessDenied.wiki
@@ -9,7 +9,7 @@
 
 @col 12
 
-h4. Access Denied.
+h4. Access Denied Please Login
 {{accessdeniedmsg}}
 
 @divend


### PR DESCRIPTION
#### What this PR resolves:
Different login methods for portal depending if it is in production mode or not

#### Changes proposed in this PR:

-  Can't login with user, password  in production mode
- Can't use oauth methods when in development mode


**Version**: 9.1.1

**Fixes**: #https://github.com/Jumpscale/portal9/issues/59
